### PR TITLE
INT-26: Fix HeroBanner mantine styling over other styles

### DIFF
--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -5,8 +5,7 @@
 }
 
 .hero {
-  padding-top: 10%;
-  height: 105vh;
+  height: 95vh;
 }
 
 .image-banner {

--- a/src/components/Banner/HeroBanner.tsx
+++ b/src/components/Banner/HeroBanner.tsx
@@ -1,5 +1,5 @@
 import { Container, Flex } from "@mantine/core";
-import "@mantine/core/styles.css";
+import "@mantine/core/styles.layer.css";
 import "@/components/Banner/Banner.css";
 import Image from "next/image";
 


### PR DESCRIPTION
## Feature

[TASK: INT-26](https://linear.app/uoftblueprint/issue/INT-26/bug-fix-herobanner-mantine-styling-overriding-other-styles)  

Description of feature or bug:

Fixed issue with Next.js not guaranteeing style import order due to conflicting mantine styles

### Screenshots/Recordings

<details>
  <summary> Click to expand!</summary>
  
  I![image](https://github.com/uoftblueprint/website-v2/assets/81433191/290fd737-0b77-4888-9e93-e5272dbb8a42)
</details>

### Important Notes

Add any important notes or commentary necessary for this PR: