### PR TITLE
Enayaamir/intl 18 join our team button update

### DIFF
--- a/src/app/about/white-section/white-section.js
+++ b/src/app/about/white-section/white-section.js
@@ -113,7 +113,7 @@ export default function WhiteSection() {
           </Text>
           <Button
             rightSection={<Image className={"arrow"} src="chevron-right.svg" />}
-            radius="lg"
+            radius="xl"
             href=""
             component="a"
             target="_blank"

--- a/src/app/about/white-section/white-section.js
+++ b/src/app/about/white-section/white-section.js
@@ -113,7 +113,7 @@ export default function WhiteSection() {
           </Text>
           <Button
             rightSection={<Image className={"arrow"} src="chevron-right.svg" />}
-            radius="xl"
+            radius="lg"
             href=""
             component="a"
             target="_blank"

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -63,6 +63,7 @@
   color: var(--clr-light);
 }
 
-.nav-join-btn:hover {
+/* Add style specifically for a "filled" button */
+.nav-join-btn[data-variant="filled"]:hover {
   background-color: var(--clr-hl1);
 }

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -25,6 +25,7 @@
     text-decoration-color 0.2s,
     text-underline-offset 0.2s;
   font-size: 18px;
+  font-weight: 400;
 }
 
 .nav-link:hover {
@@ -57,6 +58,7 @@
 
 .nav-join-link {
   font-size: 18px;
+  font-weight: 400;
   color: var(--clr-hl1);
 }
 

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -48,21 +48,23 @@
 .nav-join-btn {
   --button-radius: 26px;
   --button-height: 52px;
-  color: var(--clr-light);
+  background-color: var(--clr-light);
+  color: var(--clr-hl1);
   transition:
     color 0.3s ease-in-out,
     background-color 0.3s ease-in-out;
 }
 
-.nav-join-link {
+/*.nav-join-link {
   font-size: 18px;
   color: var(--clr-hl1);
 }
 
 .nav-join-link:hover {
   color: var(--clr-light);
-}
+}*/
 
 .nav-join-btn:hover {
   background-color: var(--clr-hl1);
+  color: var(--clr-light);
 }

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -48,7 +48,7 @@
 .nav-join-btn {
   --button-radius: 26px;
   --button-height: 52px;
-  color: var(--clr-hl1);
+  color: var(--clr-light);
   transition:
     color 0.3s ease-in-out,
     background-color 0.3s ease-in-out;
@@ -56,13 +56,13 @@
 
 .nav-join-link {
   font-size: 18px;
-  color: var(--clr-light);
-}
-
-.nav-join-link:hover {
   color: var(--clr-hl1);
 }
 
+.nav-join-link:hover {
+  color: var(--clr-light);
+}
+
 .nav-join-btn:hover {
-  background-color: var(--clr-light);
+  background-color: var(--clr-hl1);
 }

--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -64,6 +64,10 @@
   color: var(--clr-light);
 }
 
+.nav-join-btn:hover .nav-join-link {
+  color: var(--clr-light);
+}
+
 /* Add style specifically for a "filled" button */
 .nav-join-btn[data-variant="filled"]:hover {
   background-color: var(--clr-hl1);

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -22,7 +22,8 @@ function Navbar({ opened, toggleOpened, links }) {
     <Button
       variant="filled"
       color="white"
-      classNames={{ label: "nav-join-link", root: "nav-join-btn" }}
+      size="lg"
+      className="nav-join-btn"
       key="join"
       h="50px"
       component="a"

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -24,6 +24,7 @@ function Navbar({ opened, toggleOpened, links }) {
       color="white"
       classNames={{ label: "nav-join-link", root: "nav-join-btn" }}
       key="join"
+      w="175px"
       h="50px"
       component="a"
       href="/"
@@ -43,13 +44,13 @@ function Navbar({ opened, toggleOpened, links }) {
         />
       </a>
       <div className="nav-menu_container">
-        <Flex visibleFrom="md" justify={"end"} align={"center"}>
+        <Flex visibleFrom="sm" justify={"end"} align={"center"}>
           {items}
         </Flex>
         <Burger
           opened={opened}
           onClick={toggleOpened}
-          hiddenFrom="md"
+          hiddenFrom="sm"
           size="md"
           color="#FFFFFF"
         />

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -24,7 +24,6 @@ function Navbar({ opened, toggleOpened, links }) {
       color="white"
       classNames={{ label: "nav-join-link", root: "nav-join-btn" }}
       key="join"
-      w="175px"
       h="50px"
       component="a"
       href="/"

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -20,7 +20,7 @@ function Navbar({ opened, toggleOpened, links }) {
 
   items.push(
     <Button
-      variant="outline"
+      variant="filled"
       color="white"
       classNames={{ label: "nav-join-link", root: "nav-join-btn" }}
       key="join"

--- a/src/components/Navbar/SideNavMenu.tsx
+++ b/src/components/Navbar/SideNavMenu.tsx
@@ -17,8 +17,8 @@ function SideNavMenu({ links }) {
 
   items.push(
     <Button
-      variant="outline"
-      color="#FFFFFF"
+      variant="filled"
+      color="white"
       classNames={{ label: "nav-join-link", root: "nav-join-btn" }}
       key="join"
       h="50px"


### PR DESCRIPTION
Fixes [Ticket 18](https://linear.app/uoft-blueprint-internal/issue/INTL-18/join-our-team-button-update)

- Changes the "Join the Team!" button to be filled and change color on hover
- Handles the padding hover bug for the button where the text would disappear even while hovering
- Solves the font-weight differences between the about page and all others by setting a standard weight of 400 for all navbar text

## Images
![Screenshot 2024-11-01 at 23 17 24](https://github.com/user-attachments/assets/37cb5b9f-05a1-44c4-a231-caeb19e1972f)
![Screenshot 2024-11-01 at 23 18 01](https://github.com/user-attachments/assets/e6cc7cea-689e-4533-be2a-da33d6af5df9)

I could not get my cursor in the screenshot, but I am hovering in the padding part of the button for image 2

